### PR TITLE
player list sync and other changes (see PR)

### DIFF
--- a/client/config/events.ts
+++ b/client/config/events.ts
@@ -1,15 +1,16 @@
-const EVENTS ={
-  connection:"connection",
-  CLIENT:{
-    CREATE_LOBBY:"CREATE_LOBBY",
-    JOIN_LOBBY:"JOIN_LOBBY",
-    START_GAME:"START_GAME",
+const EVENTS = {
+  connection: "connection",
+  CLIENT: {
+    CREATE_LOBBY: "CREATE_LOBBY",
+    JOIN_LOBBY: "JOIN_LOBBY",
+    START_GAME: "START_GAME",
   },
-  SERVER:{
-    LOBBYS:"LOBBYS",
-    JOINED_LOBBY:"JOINED_LOBBY",
-    ROOM_PLAYER:"ROOM_PLAYER"
+  SERVER: {
+    LOBBYS: "LOBBYS",
+    JOINED_LOBBY: "JOINED_LOBBY",
+    ROOM_PLAYER: "ROOM_PLAYER",
+    LOBBY_NOT_FOUND: 'LOBBY_NOT_FOUND',
   }
-}
+};
 
 export default EVENTS;

--- a/client/context/socket.context.tsx
+++ b/client/context/socket.context.tsx
@@ -9,7 +9,7 @@ interface Context {
   setUsername: Function;
   lobbyId?: string;
   lobbys: object;
-  players?: {name:string,host:boolean}[];
+  players?: { id: string, name: string, isHost: boolean; }[];
   setPlayers: Function;
 }
 
@@ -39,18 +39,19 @@ function SocketsProvider(props: any) {
     setLobbys(value);
   });
 
-  socket.on(EVENTS.SERVER.JOINED_LOBBY, (value) => {
-    setLobbyId(value);
+  socket.on(EVENTS.SERVER.JOINED_LOBBY, ({ id, players }) => {
+    setLobbyId(id);
+    setPlayers(players);
   });
 
   useEffect(() => {
-    socket.on(EVENTS.SERVER.ROOM_PLAYER,({username,host}) => {
+    socket.on(EVENTS.SERVER.ROOM_PLAYER, (players) => {
       if (!document.hasFocus()) {
         document.title = "Joining...";
       }
-      
-      setPlayers((players)=>[...players,{username,host}])
-    })
+
+      setPlayers(players);
+    });
   }, [socket]);
 
   return (

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -25,31 +25,34 @@ export default function Home() {
     if (!name) {
       return;
     }
-    localStorage.setItem("username", name);
+    console.log('setting username in sessionstorage');
+    sessionStorage.setItem("username", name);
   };
 
   const handleCreateRoom = () => {
-    var lobbyName
+    var lobbyName;
     if (!String(newLobbyRef.current.value).trim()) {
       const nanoid = customAlphabet("0123456789", 6);
       lobbyName = nanoid();
     } else {
       lobbyName = newLobbyRef.current.value || "";
     }
-    socket.emit(EVENTS.CLIENT.CREATE_LOBBY, { lobbyName,username });
-    router.push(`/lobby/${lobbyName}`);
+    socket.emit(EVENTS.CLIENT.CREATE_LOBBY, { lobbyName, username });
   };
+
 
   const handleJoinRoom = (key) => {
     if (key === lobbyId) return;
-    socket.emit(EVENTS.CLIENT.JOIN_LOBBY, {key,username});
     router.push(`/lobby/${key}`);
   };
 
   useEffect(() => {
-    if (usernameRef.current){
-      usernameRef.current.value = localStorage.getItem("username") || "";
+    if (usernameRef.current) {
+      usernameRef.current.value = sessionStorage.getItem("username") || "";
     }
+    socket.on(EVENTS.SERVER.JOINED_LOBBY, ({ lobbyId, players }) => {
+      router.push(`/lobby/${lobbyId}`);
+    });
   }, []);
 
   return (
@@ -100,7 +103,7 @@ export default function Home() {
               <h3>Create Lobby</h3>
               <div className={styles.input}>
                 <input
-                  ref = {newLobbyRef}
+                  ref={newLobbyRef}
                   onKeyDown={(event) => {
                     event.key === "Enter" ? handleCreateRoom() : {};
                   }}

--- a/client/pages/lobby/[id].tsx
+++ b/client/pages/lobby/[id].tsx
@@ -11,25 +11,42 @@ import { useEffect, useRef } from "react";
 import EVENTS from "../../config/events";
 import { useSockets } from "../../context/socket.context";
 import { useRouter } from "next/router";
-import {io} from "socket.io-client";
+import { io } from "socket.io-client";
 
 export default function Lobby(props) {
   const { id } = props;
   const router = useRouter();
-  const { socket, lobbyId, username, players } = useSockets();
+  const { socket, lobbyId, players } = useSockets();
 
-  
+  let username: string;
   useEffect(() => {
-    console.log(socket.on(EVENTS.SERVER.ROOM_PLAYER,(players)=>{
-      console.log(players)
-    }));
+    console.log(`Socket Id: ${socket.id}`);
+    username = sessionStorage.getItem('username');
+    if (!username) {
+      console.log('Username not found in sessionstorage, redirecting');
+      router.push('/');
+      return;
+    }
+
+    console.log(`joining (key: ${router.query.id}, username: ${username})`);
+    socket.emit(EVENTS.CLIENT.JOIN_LOBBY, { lobbyId: router.query.id, username });
+
+    socket.on(EVENTS.SERVER.LOBBY_NOT_FOUND, id => {
+      console.log(`Lobby not found: ${id}`);
+      router.push('/');
+    });
+
+    socket.on(EVENTS.SERVER.ROOM_PLAYER, (players) => {
+      console.log('Player joining:');
+      console.log(players);
+    });
   }, []);
 
-  if (!lobbyId) { 
+  if (!lobbyId) {
     console.log(lobbyId);
     // router.push(`/lobby/404`);
   }
-  
+
 
   return (
     <>
@@ -39,21 +56,21 @@ export default function Lobby(props) {
       <Layout>
         <main className={styles.main}>
           <div>
-            
+
             <div className={styles.room_info}>
               <h1>Room: {props.id}</h1>
               <ul>
-                <li className={styles.ur}>
+                {/* <li className={styles.ur}>
                   <h3>
                     <FontAwesomeIcon icon={faGift} /> {username}
                   </h3>
-                </li>
+                </li> */}
                 {players.map((item) => (
                   <li key={item.name}>
                     <h3>
-                      { item.host?
-                      (<><FontAwesomeIcon icon={faCrown} /> {item.name}</>):
-                      (<><FontAwesomeIcon icon={faGift} /> {item.name}</>)
+                      {item.isHost ?
+                        (<><FontAwesomeIcon icon={faCrown} /> {item.name}</>) :
+                        (<><FontAwesomeIcon icon={faGift} /> {item.name}</>)
                       }
                     </h3>
                   </li>
@@ -72,6 +89,7 @@ export default function Lobby(props) {
           </div>
           <div className={styles.button}>
             <h3 style={{ margin: "1rem" }}>Player: {players.length}</h3>
+            <p>Your name: {username}</p>
             {players.length < 2 ? (
               <p>{3 - players.length} more player to start</p>
             ) : (

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -2,24 +2,24 @@ import { nanoid } from "nanoid";
 import { Server, Socket } from "socket.io";
 import logger from "./utils/logger";
 
-const EVENTS ={
-  connection:"connection",
-  CLIENT:{
-    CREATE_LOBBY:"CREATE_LOBBY",
-    JOIN_LOBBY:"JOIN_LOBBY",
-    START_GAME:"START_GAME",
+const EVENTS = {
+  connection: "connection",
+  CLIENT: {
+    CREATE_LOBBY: "CREATE_LOBBY",
+    JOIN_LOBBY: "JOIN_LOBBY",
+    START_GAME: "START_GAME",
   },
-  SERVER:{
-    LOBBYS:"LOBBYS",
-    JOINED_LOBBY:"JOINED_LOBBY",
-    ROOM_PLAYER:"ROOM_PLAYER"
+  SERVER: {
+    LOBBYS: "LOBBYS",
+    JOINED_LOBBY: "JOINED_LOBBY",
+    ROOM_PLAYER: "ROOM_PLAYER"
   }
-}
+};
 
 
-const lobbys:Record<string,{name:string}> = {}
+const lobbys = new Map<string, { name: string; players: { id: string, name: string, isHost: boolean; }[]; }>();
 
-function socket({ io }: { io: Server }) {
+function socket({ io }: { io: Server; }) {
   logger.info(`Sockets enabled`);
 
   io.on(EVENTS.connection, (socket: Socket) => {
@@ -30,36 +30,53 @@ function socket({ io }: { io: Server }) {
     /*
      * When a user creates a new room
      */
-    socket.on(EVENTS.CLIENT.CREATE_LOBBY, ({ lobbyName,username }) => {
+    socket.on(EVENTS.CLIENT.CREATE_LOBBY, ({ lobbyName, username }) => {
       console.log({ lobbyName });
       // create a roomId
       const lobbyId = nanoid();
       // add a new room to the rooms object
-      lobbys[lobbyId] = {
+      lobbys.set(lobbyId, {
         name: lobbyName,
-      };
-      socket.join(lobbyId);
+        players: []
+      });
+
+      const lobby = lobbys.get(lobbyId);
+      // socket.join(lobbyId);
+
+      console.log(`lobby created: ID: ${lobbyId}, Name: ${lobbyName}`);
+
+      lobby!.players.push({ id: socket.id, name: username, isHost: true });
 
       // broadcast an event saying there is a new room
-      socket.broadcast.emit(EVENTS.SERVER.LOBBYS, lobbys);
+      // socket.broadcast.emit(EVENTS.SERVER.LOBBYS, lobbys); // (disabled for security reasons)
 
       // emit back to the room creator with all the rooms
       socket.emit(EVENTS.SERVER.LOBBYS, lobbys);
       // emit event back the room creator saying they have joined a room
-      socket.emit(EVENTS.SERVER.JOINED_LOBBY, lobbyId);
-      socket.to(lobbyId).emit(EVENTS.SERVER.ROOM_PLAYER,({name:username,host:true}))
+      socket.emit(EVENTS.SERVER.JOINED_LOBBY, { lobbyId: lobbyId, players: lobby!.players });
+      // socket.to(lobbyId).emit(EVENTS.SERVER.ROOM_PLAYER, lobby!.players); // will reach no one
     });
 
-    socket.on(EVENTS.CLIENT.START_GAME,()=>{})
+    socket.on(EVENTS.CLIENT.START_GAME, () => { });
     /*
      * When a user joins a room
      */
-    socket.on(EVENTS.CLIENT.JOIN_LOBBY, ({lobbyId,username}) => {
-      socket.join(lobbyId);
-      socket.to(lobbyId).emit(EVENTS.SERVER.ROOM_PLAYER,({name:username,host:false}))
-      socket.emit(EVENTS.SERVER.JOINED_LOBBY, lobbyId);
+    socket.on(EVENTS.CLIENT.JOIN_LOBBY, async ({ lobbyId, username }) => {
+      console.log(`User trying to join (${username} -> ${lobbyId}), Available (${lobbys.size}): ${JSON.stringify(lobbys)}`);
+      const lobby = lobbys.get(lobbyId);
+      if (!lobby) {
+        socket.emit('LOBBY_NOT_FOUND', lobbyId);
+        return;
+      }
+      // io.sockets.adapter.rooms[]
+      await socket.join(lobbyId);
+      if (!lobby.players.find(p => p.id == socket.id))
+        lobby.players.push({ id: socket.id, name: username, isHost: false });
+      socket.emit(EVENTS.SERVER.JOINED_LOBBY, { lobbyId, players: lobby.players });
+      socket.to(lobbyId).emit(EVENTS.SERVER.ROOM_PLAYER, lobby.players);
+      console.log('Join approved.');
     });
-    
+
   });
 }
 


### PR DESCRIPTION
I've managed to sync player list with all connected clients in a room by broadcasting the entire player list cached on the server. Currently, userId is added to `lobbys.players` to prevent duplicate joining after room create event. (I grab the userId from socket id) However, duplicates can still occur when the page is reloaded or refreshed. This is due to socket connection being reconnected, hence new socket id. **I recommend you implement a manually generated user id system to circumvent said problem.**

Additional changes:
- cache player list on server
- redirect user to home page if requested room id doesn't exist
- save username to `sessionStorage`, however not properly integrated with *socket context* yet (please do it yourself)
- redirect user if username is absent from `sessionStorage`